### PR TITLE
add logger and fix bug issue #19

### DIFF
--- a/bqrole/dataset.go
+++ b/bqrole/dataset.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	bq "cloud.google.com/go/bigquery"
+	"github.com/rs/zerolog/log"
 )
 
 func DatasetRole(role string) (bq.AccessRole, error) {
@@ -93,7 +94,7 @@ func grantBQJobUser(project, user string) error {
 	}
 
 	if hasBQJobUser(*policy, user) { // already has roles/bigquery.jobUser
-		fmt.Printf("%s already have bigquery.jobUser\n", user)
+		log.Info().Msgf("%s already have bigquery.jobUser\n", user)
 		return nil
 	}
 

--- a/bqrole/project.go
+++ b/bqrole/project.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	bq "cloud.google.com/go/bigquery"
+	"github.com/rs/zerolog/log"
 )
 
 func ProjectRole(role string) (string, error) {
@@ -63,8 +64,9 @@ func grantProjectRole(project, user, role string) error {
 		return fmt.Errorf("failed to fetch current policy: error %s", err)
 	}
 
-	if hasProjectRole(*policy, user, role) {
-		return fmt.Errorf("%s already has a role: %s, project: %s", user, role, project)
+	if hasProjectRole(*policy, user, role) { // already has roles/viewer
+		log.Info().Msgf("%s already has a role: %s, project: %s. skipped.", user, role, project)
+		return nil
 	}
 
 	var member string

--- a/cmd/permit.go
+++ b/cmd/permit.go
@@ -94,7 +94,6 @@ func runPermitProjectCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	err = bqrole.PermitProject(role, project, users)
-
 	if err != nil {
 		return fmt.Errorf("failed to permit: %s", err)
 	}
@@ -151,7 +150,6 @@ func runPermitDatasetCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	err = bqrole.PermitDataset(role, project, users, datasets)
-
 	if err != nil {
 		return fmt.Errorf("failed to permit: %s", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hirosassa/bqiam
 
-go 1.14
+go 1.15
 
 require (
 	cloud.google.com/go/bigquery v1.0.1
@@ -9,6 +9,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/pelletier/go-toml v1.8.0 // indirect
+	github.com/rs/zerolog v1.19.0
 	github.com/spf13/afero v1.3.2 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/cobra v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -175,6 +175,9 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
+github.com/rs/zerolog v1.19.0 h1:hYz4ZVdUgjXTBUmrkrw55j1nHx68LfOKIQk5IYtyScg=
+github.com/rs/zerolog v1.19.0/go.mod h1:IzD0RJ65iWH0w97OQQebJEvTZYvsCUm9WVLWBQrJRjo=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
@@ -318,6 +321,7 @@ golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20190828213141-aed303cbaa74/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc h1:NCy3Ohtk6Iny5V/reW2Ktypo4zIpWBdRJ1uFMjBxdg8=


### PR DESCRIPTION
# What is this PR?

fix #19 and #3 

I also introduce `zerolog` for verbose outputs

### usage
```bash 
$ bqiam permit project READER -p sample-project-id -u use@example.com -v // added verbose option flag
project_id: sample-project-id
role:       roles/viewer
users:      [use@example.com]
If you proceeds, PROJECT-WIDE permission will be added. Are you sure? [y/n]y
{"level":"info","time":"2020-09-05T16:00:45+09:00","message":"use@example.com already has a role: roles/viewer, project: sample-project-id. skipped."}. // This is a verbose output.
Permit  use@example.com to sample-project-id access as roles/viewer
```