### PR TITLE
handle error message produced by exec.Command.Output()

### DIFF
--- a/bqrole/dataset.go
+++ b/bqrole/dataset.go
@@ -90,7 +90,7 @@ func PermitDataset(role bq.AccessRole, project string, users, datasets []string)
 func grantBQJobUser(project, user string) error {
 	policy, err := fetchCurrentPolicy(project)
 	if err != nil {
-		return fmt.Errorf("failed to fetch current policy: error %s", err)
+		return fmt.Errorf("failed to fetch current policy: %s", err)
 	}
 
 	if hasBQJobUser(*policy, user) { // already has roles/bigquery.jobUser
@@ -108,7 +108,7 @@ func grantBQJobUser(project, user string) error {
 	cmd := fmt.Sprintf("gcloud projects add-iam-policy-binding %s --member %s --role roles/bigquery.jobUser", project, member)
 	err = exec.Command("bash", "-c", cmd).Run()
 	if err != nil {
-		return fmt.Errorf("failed to update policy bindings to grant %s roles/bigquery.jobUser: error: %s", user, err)
+		return fmt.Errorf("failed to update policy bindings to grant %s roles/bigquery.jobUser: %s", user, err)
 	}
 
 	return nil

--- a/bqrole/project.go
+++ b/bqrole/project.go
@@ -61,7 +61,7 @@ func PermitProject(role, project string, users []string) error {
 func grantProjectRole(project, user, role string) error {
 	policy, err := fetchCurrentPolicy(project)
 	if err != nil {
-		return fmt.Errorf("failed to fetch current policy: error %s", err)
+		return fmt.Errorf("failed to fetch current policy: %s", err)
 	}
 
 	if hasProjectRole(*policy, user, role) { // already has roles/viewer
@@ -79,7 +79,7 @@ func grantProjectRole(project, user, role string) error {
 	cmd := fmt.Sprintf("gcloud projects add-iam-policy-binding %s --member %s --role %s", project, member, role)
 	err = exec.Command("bash", "-c", cmd).Run()
 	if err != nil {
-		return fmt.Errorf("failed to update policy bindings to grant %s %s: error: %s", user, role, err)
+		return fmt.Errorf("failed to update policy bindings to grant %s %s: %s\n%s", user, role, err, err.(*exec.ExitError).Stderr)
 	}
 
 	return nil

--- a/bqrole/util.go
+++ b/bqrole/util.go
@@ -20,7 +20,7 @@ func fetchCurrentPolicy(project string) (*ProjectPolicy, error) {
 	cmd := fmt.Sprintf("gcloud projects get-iam-policy %s --format=json", project)
 	policyJson, err := exec.Command("bash", "-c", cmd).Output()
 	if err != nil {
-		return nil, fmt.Errorf("failed to run gcloud command to get current iam policy: error: %s", err)
+		return nil, fmt.Errorf("failed to run gcloud command to get current iam policy: %s\n%s", err, err.(*exec.ExitError).Stderr)
 	}
 
 	var policy ProjectPolicy

--- a/cmd/dataset.go
+++ b/cmd/dataset.go
@@ -69,7 +69,7 @@ func refreshCache(cmd *cobra.Command) {
 func checkCacheExpired(filename string) (bool, error) {
 	t, err := times.Stat(filename)
 	if err != nil {
-		return false, fmt.Errorf("Failed to get file modified timestamp: err: %s", err)
+		return false, fmt.Errorf("Failed to get file modified timestamp: %s", err)
 	}
 
 	timePassed := time.Since(t.ModTime()).Hours()


### PR DESCRIPTION
# What is this PR?

fix #18 

I implemented error handling when the `gcloud` coomand is failed.
It outputs error messages to `stderr`, so I wrote the code which capturing it.

## sample output

```
$bqiam permit project READER -p sample-project -u testtesttesttest@samplesamplesample.com
project_id: sample-project
role:       roles/viewer
users:      [testtesttesttest@samplesamplesample.com]
If you proceeds, PROJECT-WIDE permission will be added. Are you sure? [y/n]y
Error: failed to permit: failed to fetch current policy: error failed to run gcloud command to get current iam policy: exit status 1
ERROR: (gcloud.projects.get-iam-policy) You do not currently have an active account selected.
Please run:

  $ gcloud auth login

to obtain new credentials.

If you have already logged in with a different account:

    $ gcloud config set account ACCOUNT

to select an already authenticated account to use.
```